### PR TITLE
Integrate auth

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { ReactNode } from "react";
+import { ApolloProvider } from "@apollo/client";
 import { Header } from "~components/AppHeader";
 import { PageLayout } from "~honeycomb";
+import apolloClient from "~lib/apollo";
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   return (
@@ -10,7 +12,11 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       <PageLayout.Header>
         <Header />
       </PageLayout.Header>
-      <PageLayout.Main>{children}</PageLayout.Main>
+      <PageLayout.Main>
+        <ApolloProvider client={apolloClient}>
+          {children}
+        </ApolloProvider>
+      </PageLayout.Main>
     </PageLayout>
   );
 }

--- a/app/(app)/send-magic-link/page.tsx
+++ b/app/(app)/send-magic-link/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import { gql, useMutation } from "@apollo/client";
+
+import { Button } from "~honeycomb";
+
+const SIGN_UP = gql`
+  mutation SendMagicLink($email: String!) {
+    sendMagicLink(email: $email) {
+      ok
+    }
+  }
+`;
+
+export default function Page() {
+  const [email, setEmail] = useState("");
+  const [signUp, { data, loading, error }] = useMutation(SIGN_UP);
+
+  if (loading) return "Loading...";
+  if (error) {
+    console.log(error)
+    return (
+      <div>
+        <h2>Something went wrong</h2>
+        <p>{error.message}</p>
+      </div>
+    );
+  }
+
+  if (data) {
+    console.log(data, email)
+    return (
+      <div>
+        <h2>Check your email</h2>
+        <p>
+          We sent you a magic link to <strong>{email}</strong>. Click the link
+          to sign in.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <form onSubmit={() => signUp({ variables: { email }})}>
+        <input
+            id="email"
+            type="email"
+            name="email"
+            value={email}
+            placeholder="mary.poppins@email.com"
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <Button
+            type="submit"
+            onClick={() => {}}
+          >
+            Sign up
+          </Button>
+      </form>
+    </>
+  );
+}

--- a/app/(workflows)/auth/page.tsx
+++ b/app/(workflows)/auth/page.tsx
@@ -24,8 +24,11 @@ const MY_USER = gql`
 
 export default function Page() {
   const searchParams = useSearchParams();
-  const token = searchParams.get("token");
+  const secretToken = searchParams.get("token");
   const id = searchParams.get("id");
+
+  const storedAuth = JSON.parse(localStorage.getItem("auth") || "{}");
+  const { id: storedId } = storedAuth;
 
   const {
     data: userData,
@@ -33,13 +36,14 @@ export default function Page() {
     error: userError,
   } = useQuery(MY_USER, {
     variables: {
-      id: "RZxkLgwBptW8UtVO2hw_v",
+      id: storedId,
     },
   });
+
   const [signIn, { data, loading, error }] = useMutation(SIGN_IN, {
     variables: {
-      id: "RZxkLgwBptW8UtVO2hw_v",
-      secretToken: "PlGx72cIybkjVbMfv04zp",
+      id,
+      secretToken,
     },
   });
 
@@ -52,7 +56,7 @@ export default function Page() {
 
   return (
     <>
-      <h1>Hello, Signup Page</h1> <Link href="/dashboard">Signup</Link>
+      <h1>Hello, Signup Page</h1> <Link href="/signup">Signup</Link>
       {JSON.stringify(data)}
     </>
   );

--- a/app/(workflows)/layout.tsx
+++ b/app/(workflows)/layout.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import Link from "next/link";
+import { ApolloProvider } from "@apollo/client";
 import { ReactNode } from "react";
 import { PageLayout } from "~honeycomb";
+import apolloClient from "~lib/apollo";
 
 import styles from "./workflow-layout.module.css";
 
@@ -13,7 +15,9 @@ export default function WorkflowLayout({ children }: { children: ReactNode }) {
         <Link href="/">BoardgameSesh</Link>
       </PageLayout.Header>
       <PageLayout.Main classNameExtend={styles.container}>
-        {children}
+        <ApolloProvider client={apolloClient}>
+          {children}
+        </ApolloProvider>
       </PageLayout.Main>
     </PageLayout>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+      </body>
     </html>
   );
 }

--- a/lib/apollo.ts
+++ b/lib/apollo.ts
@@ -3,7 +3,7 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 
 const client = new ApolloClient({
-  uri: "https://dav78fegll.execute-api.ap-southeast-2.amazonaws.com/",
+  uri: "https://97ff7w8216.execute-api.ap-southeast-2.amazonaws.com",
   cache: new InMemoryCache(),
 });
 

--- a/packages/honeycomb/Button/Button.tsx
+++ b/packages/honeycomb/Button/Button.tsx
@@ -7,6 +7,7 @@ export const Button = ({
   intent,
   size,
   mood,
+  type,
   onClick,
 }: {
   children: ReactNode;
@@ -14,8 +15,10 @@ export const Button = ({
   intent?: string;
   size?: string;
   mood?: string;
+  type?: "button" | "submit" | "reset";
 }) => (
   <button
+    type={type || "button"}
     onClick={onClick}
     className={clsx(styles.base, {
       [styles.secondary]: intent === "secondary",


### PR DESCRIPTION
# WIP don't merge just yet

making sure email sending is working, and working through issues where we store the token in localstorage on sign in and keep it fresh

The underlying mechanism of authentication has nothing to do with the token really, because the true auth system is JS inaccessible cookies stored in `httpOnly` but we do trust the end user enough to let them fire off graphql commands once they have a stored id/token, because if they do, then their cookie will also be set in the same way. We trust them to do frontend shit if they have stored a localstorage token, but the real mechanism isn't that token, it's just a representation of trust occurring outside their control.


Still todo:
1. clean up the routes because we probably don't need a new page at that level to send a magic link to sign in
2. add "auth" checking to routes in a sustainable way
3. make it pretty


Getting there!